### PR TITLE
made output file include resource group when included in command line

### DIFF
--- a/az2tf.sh
+++ b/az2tf.sh
@@ -27,14 +27,20 @@ fi
 export ARM_SUBSCRIPTION_ID="$mysub"
 az account set -s $mysub
 
-mkdir -p tf.$mysub
-cd tf.$mysub
-rm -rf .terraform
+#mkdir -p tf.$mysub
+#cd tf.$mysub
+#rm -rf .terraform
 
 if [ "$2" != "" ]; then
     myrg=$2
+    mkdir -p tf.${mysub}_${myrg}
+    cd tf.${mysub}_${myrg}
+    rm -rf .terraform
     ../scripts/resources.sh $myrg
 else
+    mkdir -p tf.$mysub
+    cd tf.$mysub
+    rm -rf .terraform
     ../scripts/resources.sh
 fi
 

--- a/scripts/azurerm_express_route_circuit_peering.sh
+++ b/scripts/azurerm_express_route_circuit_peering.sh
@@ -61,10 +61,11 @@ if [ "$count2" -gt "0" ]; then
                 printf "\t peer_asn = \"%s\"\n" $pasn >> $prefix-$name.tf
                 
 
-                if [ "$peering_type" = "MicrosoftPeering" ];then
-                printf "\t microsoft_peering_config {\n" >> $prefix-$name.tf
-                printf "\t\t advertised_public_prefixes = %s\n" "$app" >> $prefix-$name.tf
-                printf "\t } \n" >> $prefix-$name.tf
+                if [ "$pt" = "MicrosoftPeering" ] || [ "$pt" = "AzurePrivatePeering" ];then
+                    app=`echo $peers | jq ".[(${k})].properties.microsoftPeeringConfig.advertisedPublicPrefixes"`
+                    printf "\t microsoft_peering_config {\n" >> $prefix-$name.tf
+                    printf "\t\t advertised_public_prefixes = %s\n" "$app" >> $prefix-$name.tf
+                    printf "\t } \n" >> $prefix-$name.tf
                 fi
 
                 #


### PR DESCRIPTION
When importing a resource group at a time, it is helpful to have the output directories be unique to the rg name and not over-write other imports from the same subscription. 