### PR TITLE
azurerm_log_analytics_workspace.sh invalid retention_days

### DIFF
--- a/scripts/azurerm_log_analytics_workspace.sh
+++ b/scripts/azurerm_log_analytics_workspace.sh
@@ -40,7 +40,10 @@ if [ "$count2" -gt "0" ]; then
                 printf "\t location = %s\n" "$loc" >> $prefix-$name.tf
                 printf "\t resource_group_name = \"%s\"\n" $rg >> $prefix-$name.tf            
                 printf "\t sku = %s \n" "$sku" >> $prefix-$name.tf
-                printf "\t retention_in_days = %s \n" "$rdays" >> $prefix-$name.tf
+                # 7 is not a valid value, but is the default reported from AZ api. If 7, skip to avoid triggering plan difference
+                if [ "$rdays" -ne "7" ]; then
+                    printf "\t retention_in_days = %s \n" "$rdays" >> $prefix-$name.tf
+                fi
                 
                 #
                 # New Tags block


### PR DESCRIPTION
If rdays == 7 (which is an invalid value), dont add to retention_days .tf file. Valid valise must be between 30 and 120